### PR TITLE
Correct aspect change when fully zoomed out.

### DIFF
--- a/css/phylowood.css
+++ b/css/phylowood.css
@@ -25,15 +25,15 @@ svg {
 
 #divPhylo {
 	background-color:#FFE700;
-	height:600px;
-	width:600px;
+	height:500px;
+	width:350px;
 	float:left;
 }
 
 #divGeo {
 	background-color:#FFD700;
-	height:600px;
-	width:600px;
+	height:500px;
+	width:850px;
 	float:left;
 }
 

--- a/js/phylowood.js
+++ b/js/phylowood.js
@@ -630,19 +630,19 @@ Phylowood.initMap = function() {
 	// need to center map at {0,0} when zoom is 1 to put entire globe in view
 	while (minLat < map.extent()[0].lat) { 
 		map.zoomBy(-1); 
-		if (map.zoom() == 1) { map.center({lat:0,lon:0}) }
+		if (map.zoom() <= 2) { map.center({lat:20,lon:20}) }
 	}
 	while (minLon < map.extent()[0].lon) { 
 		map.zoomBy(-1); 
-		if (map.zoom() == 1) { map.center({lat:0,lon:0}) }		
+		if (map.zoom() <= 2) { map.center({lat:20,lon:20}) }		
 	}	
 	while (maxLat > map.extent()[1].lat) { 
 		map.zoomBy(-1); 
-		if (map.zoom() == 1) { map.center({lat:0,lon:0}) }		
+		if (map.zoom() <= 2) { map.center({lat:20,lon:20}) }		
 	}	
 	while (maxLon > map.extent()[1].lon) { 
 		map.zoomBy(-1); 
-		if (map.zoom() == 1) { map.center({lat:0,lon:0}) }		
+		if (map.zoom() <= 2) { map.center({lat:20,lon:20}) }		
 	}		
 		
 	var layer = d3.select("#divGeo svg").insert("svg:g", ".compass");


### PR DESCRIPTION
Currently, the 1:1 aspect ratio of the map doesn't work with a zoomed out view.  End up with white space above and below and the ugly Mercator effects on Greenland and Antarctica.  I'd suggest a wider geo div and a narrower phylo div. 
